### PR TITLE
Feature/first letter import

### DIFF
--- a/app/blueprints/api.py
+++ b/app/blueprints/api.py
@@ -22,6 +22,9 @@ def sheet():
     if request.args.get('location'):
         entries = entries.where('location', '==', request.args.get('location'))
 
+    if request.args.get('first_letter'):
+        entries = entries.where('name_first_letter', '==', request.args.get('first_letter'))
+
     results = entries.get()
     return jsonify([result.to_dict() for result in results])
 

--- a/app/blueprints/api.py
+++ b/app/blueprints/api.py
@@ -27,11 +27,11 @@ def entry_list():
             entries = entries.where('location', '==', request.args.get('location'))
 
         if request.args.get('first_letter'):
-            entries = entries.where('name_first_letter', '==', request.args.get('first_letter'))
+            entries = entries.where('name_first_letter', '==', request.args.get('first_letter').lower())
 
         results = [entry.to_dict() for entry in entries.get()]
         cache.set(cache_key, results, timeout=60 * 30)
-        
+
     return jsonify(results)
 
 

--- a/app/blueprints/api.py
+++ b/app/blueprints/api.py
@@ -31,7 +31,6 @@ def entry_list():
 
         results = [entry.to_dict() for entry in entries.get()]
         cache.set(cache_key, results, timeout=60 * 30)
-
     return jsonify(results)
 
 

--- a/app/blueprints/cron.py
+++ b/app/blueprints/cron.py
@@ -61,5 +61,6 @@ def get_values_from_sheet():
                 obj[field] = value
             except IndexError:
                 obj[field] = ''  # some fields may be empty which truncates the row data
+            obj['name_first_letter'] = obj['name'][0] if obj['name'][0].isalnum() else '#'
             values.append(obj)
     return values

--- a/app/blueprints/cron.py
+++ b/app/blueprints/cron.py
@@ -61,6 +61,6 @@ def get_values_from_sheet():
                 obj[field] = value
             except IndexError:
                 obj[field] = ''  # some fields may be empty which truncates the row data
-            obj['name_first_letter'] = obj['name'][0] if obj['name'][0].isalnum() else '#'
+            obj['name_first_letter'] = obj['name'][0].lower() if obj['name'][0].isalnum() else '#'
             values.append(obj)
     return values

--- a/app/blueprints/cron.py
+++ b/app/blueprints/cron.py
@@ -61,6 +61,6 @@ def get_values_from_sheet():
                 obj[field] = value
             except IndexError:
                 obj[field] = ''  # some fields may be empty which truncates the row data
-            obj['name_first_letter'] = obj['name'][0].lower() if obj['name'][0].isalnum() else '#'
-            values.append(obj)
+        obj['name_first_letter'] = obj['name'][0].lower() if obj['name'][0].isalnum() else '#'
+        values.append(obj)
     return values


### PR DESCRIPTION
@jcox-dev because we can't do partial matches i.e. "WHERE title LIKE f%" (a limitation I presume for scalability/speed), we have to store the first letter in a column on import - hence the change in import script. For anything non alphanumeric I store as "#" for easier filtering, once I know how I'm presenting it frontend I might also include numbers as part of the #, but for now this gives me what I need to carry on with the frontend.